### PR TITLE
Update daily_cpFromTablo

### DIFF
--- a/surlatablo/Dockerfile
+++ b/surlatablo/Dockerfile
@@ -33,3 +33,4 @@ RUN chmod +x /etc/cron.daily/daily_cpFromTablo \
 RUN mkdir -p /etc/my_init.d
 ADD /config/scripts/firstrun.sh /etc/my_init.d/firstrun.sh
 RUN chmod +x /etc/my_init.d/firstrun.sh
+CMD cron && tail -f /var/log/cron.log

--- a/surlatablo/config/cron.daily/daily_cpFromTablo
+++ b/surlatablo/config/cron.daily/daily_cpFromTablo
@@ -2,6 +2,6 @@
 
 # script abstraction to make this container more flexible and
 #  minimize the need to rebuild.
-/config/scripts/cpFromTablo
+/config/scripts/cpFromTablo >> /var/log/cron.log 2>&1
 
 exit 0


### PR DESCRIPTION
redirect the stderr and stdout of the cpFromTablo script to cron.log.
